### PR TITLE
fix bug related to calculating tip

### DIFF
--- a/Tip Calculator ocd JS/calculator.js
+++ b/Tip Calculator ocd JS/calculator.js
@@ -23,8 +23,7 @@ function totalAmount(billTotal, selectedPer, numPpl) {
     let totalAmount = tipAmount + billTotal;
     //Does the OCD calculations by rounding the total bill amount up to make a whole number. Then taking that number and subtracting it from the total bill, which gives you a new tip amount that makes the bill total to be a whole number.
     let ocdTotalAmount = Math.ceil(totalAmount);
-    let ocdTipAmount = ocdTotalAmount - totalAmount;
-    let newTip = new Number((ocdTotalAmount - billTotal)).toFixed(2);
+    let newTip = new Number((ocdTotalAmount - billTotal).toFixed(2));
     
     let billInfo = {
         prevBillTotal: billTotal,

--- a/Tip Calculator ocd JS/calculator.js
+++ b/Tip Calculator ocd JS/calculator.js
@@ -23,7 +23,7 @@ function totalAmount(billTotal, selectedPer, numPpl) {
     let totalAmount = tipAmount + billTotal;
     //Does the OCD calculations by rounding the total bill amount up to make a whole number. Then taking that number and subtracting it from the total bill, which gives you a new tip amount that makes the bill total to be a whole number.
     let ocdTotalAmount = Math.ceil(totalAmount);
-    let newTip = new Number((ocdTotalAmount - billTotal).toFixed(2));
+    let newTip = Number((ocdTotalAmount - billTotal).toFixed(2));
     
     let billInfo = {
         prevBillTotal: billTotal,

--- a/Tip Calculator ocd JS/calculator.js
+++ b/Tip Calculator ocd JS/calculator.js
@@ -24,7 +24,7 @@ function totalAmount(billTotal, selectedPer, numPpl) {
     //Does the OCD calculations by rounding the total bill amount up to make a whole number. Then taking that number and subtracting it from the total bill, which gives you a new tip amount that makes the bill total to be a whole number.
     let ocdTotalAmount = Math.ceil(totalAmount);
     let ocdTipAmount = ocdTotalAmount - totalAmount;
-    let newTip = new Number((ocdTipAmount + tipAmount)).toFixed(2);
+    let newTip = new Number((ocdTotalAmount - billTotal)).toFixed(2);
     
     let billInfo = {
         prevBillTotal: billTotal,
@@ -57,7 +57,7 @@ function splitBill(splitTotal, numPpl) {
 
 //Get the bill that is entered.
 function getTotalbill() {
-    return parseInt(document.getElementById('totalBillInput').value);
+    return parseFloat(document.getElementById('totalBillInput').value);
 }
 //Get the number of people entered.
 function getNumPpl() {


### PR DESCRIPTION
* Use `parseFloat` and not `parseInt` if we `parseInt` we'll only get a whole number, and it won't include change.
* Really to get the final tip we should just minus the bill total from the new ocd final total which includes the standard tip and rounding.